### PR TITLE
Fix README formatting and document POST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,20 @@ echo 'SHUTDOWN_TOKEN="super-secret-string"' | sudo tee /etc/default/pi-shutdown
 sudo cp pi-shutdown.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now pi-shutdown.service
+```
+
+## Using the API
+
+Send your secret token in a JSON body when calling the service:
+
+```bash
+# Shut down the Pi
+curl -X POST http://<PI_IP>:5000/shutdown \
+  -H 'Content-Type: application/json' \
+  -d '{"token":"YOUR_SECRET"}'
+
+# Reboot the Pi
+curl -X POST http://<PI_IP>:5000/reboot \
+  -H 'Content-Type: application/json' \
+  -d '{"token":"YOUR_SECRET"}'
+```


### PR DESCRIPTION
## Summary
- close the Quick Start code block
- add a section documenting POST `/shutdown` and `/reboot` endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dff89cc688324bd9d927dcd3a8cfb