### PR TITLE
Add reboot endpoint

### DIFF
--- a/api.py
+++ b/api.py
@@ -12,6 +12,7 @@ from flask import Flask, request, abort
 # ─── CONFIGURATION ─────────────────────────────────────────────────────────────
 SECRET = os.getenv("SHUTDOWN_TOKEN", "CHANGE-ME")  # override in /etc/default
 SHUTDOWN_CMD = ["/sbin/shutdown", "-h", "now"]     # or tweak to suit
+REBOOT_CMD = ["/sbin/shutdown", "-r", "now"]       # reboot the Pi
 # ───────────────────────────────────────────────────────────────────────────────
 
 app = Flask(__name__)
@@ -26,6 +27,18 @@ def shutdown():
     # Fire-and-forget so Flask can return immediately
     subprocess.Popen(["sudo", *SHUTDOWN_CMD])
     return "Shutting down…\n", 202
+
+
+@app.route("/reboot", methods=["POST"])
+def reboot():
+    data = request.get_json(silent=True)
+    if data is None:
+        abort(400, description="Missing JSON body")
+    if data.get("token") != SECRET:
+        abort(403, description="Bad token")
+    # Fire-and-forget so Flask can return immediately
+    subprocess.Popen(["sudo", *REBOOT_CMD])
+    return "Rebooting…\n", 202
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)


### PR DESCRIPTION
## Summary
- implement `/reboot` endpoint in `api.py` that reboots the Pi
- reuse token logic from the shutdown route
- keep configuration constants for reboot command

## Testing
- `python3 -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e012fa1f483249f827d520818a1d0