### PR TITLE
Switch service to gunicorn

### DIFF
--- a/pi-shutdown.service
+++ b/pi-shutdown.service
@@ -6,7 +6,7 @@ After=network.target
 User=pi
 EnvironmentFile=/etc/default/pi-shutdown     # optional token override
 WorkingDirectory=/opt/pi-shutdown
-ExecStart=/usr/bin/python3 /opt/pi-shutdown/api.py
+ExecStart=/usr/bin/gunicorn -w 2 api:app
 # Let the shutdown command run even if Flask is killed
 KillMode=process
 Restart=on-failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Flask>=3.0,<4
+gunicorn>=21


### PR DESCRIPTION
## Summary
- run the API via gunicorn with two workers
- add gunicorn dependency

## Testing
- `python3 -m py_compile api.py`
- `pip install -r requirements.txt` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685e035835348324be1158d6435e30e7