### PR TITLE
Add installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,15 @@ python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
 
-# 2) Move code to /opt and set up sudo
-sudo mkdir -p /opt/pi-shutdown
-sudo cp -r . /opt/pi-shutdown
+# 2) Set up sudo rights for the shutdown command
 echo "pi ALL=(root) NOPASSWD:/sbin/shutdown" \
   | sudo tee /etc/sudoers.d/pi-shutdown
 
 # 3) (Optional) override the token system-wide
 echo 'SHUTDOWN_TOKEN="super-secret-string"' | sudo tee /etc/default/pi-shutdown
 
-# 4) Enable and start the service
-sudo cp pi-shutdown.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now pi-shutdown.service
+# 4) Install or update the service
+sudo ./install.sh
 ```
 
 ## Using the API

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Install or update the pi-shutdown service
+
+DEST=/opt/pi-shutdown
+SERVICE=pi-shutdown.service
+
+# copy application files
+sudo mkdir -p "$DEST"
+# sync files excluding git directory and installer itself
+sudo rsync -a --delete --exclude '.git' --exclude 'install.sh' ./ "$DEST"/
+
+# install systemd service
+sudo install -m 644 "$SERVICE" /etc/systemd/system/$SERVICE
+
+# reload systemd and enable service
+sudo systemctl daemon-reload
+sudo systemctl enable "$SERVICE"
+
+# restart service if running, otherwise start it
+if sudo systemctl is-active --quiet "$SERVICE"; then
+    sudo systemctl restart "$SERVICE"
+else
+    sudo systemctl start "$SERVICE"
+fi
+
+echo "Installation complete"


### PR DESCRIPTION
## Summary
- add `install.sh` for quick install or update
- document installer usage in the README

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e055ee88083249ad1a1b4abac68d3