### PR TITLE
Update README for new API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A micro-service that lets **any Shelly Plus (or other smart switch)** shut down
 a Raspberry Pi gracefully via an HTTP webhook.
 
 ## How it works
-1. Shelly sends  
-   `http://<PI_IP>:5000/shutdown?token=YOUR_SECRET`
-2. `api.py` verifies the token and runs  
+1. Shelly sends a POST request to
+   `http://<PI_IP>:8000/shutdown` with `{"token": "YOUR_SECRET"}`
+2. `api.py` (via Gunicorn) verifies the token and runs
    `sudo shutdown -h now`.
 3. Pi halts cleanly, avoiding SD-card corruption.
 
@@ -31,18 +31,20 @@ echo 'SHUTDOWN_TOKEN="super-secret-string"' | sudo tee /etc/default/pi-shutdown
 sudo bash install.sh
 ```
 
+The service listens on port 8000 once started.
+
 ## Using the API
 
 Send your secret token in a JSON body when calling the service:
 
 ```bash
 # Shut down the Pi
-curl -X POST http://<PI_IP>:5000/shutdown \
+curl -X POST http://<PI_IP>:8000/shutdown \
   -H 'Content-Type: application/json' \
   -d '{"token":"YOUR_SECRET"}'
 
 # Reboot the Pi
-curl -X POST http://<PI_IP>:5000/reboot \
+curl -X POST http://<PI_IP>:8000/reboot \
   -H 'Content-Type: application/json' \
   -d '{"token":"YOUR_SECRET"}'
 ```


### PR DESCRIPTION
## Summary
- document POST usage and port 8000
- mention service port after install
- update curl examples

## Testing
- `python -m py_compile api.py`


------
https://chatgpt.com/codex/tasks/task_e_685e0b2079548324a2e2158372aafc9f