### PR TITLE
Convert endpoints to GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ avoid SD-card corruption.
 
 | Step | What happens | Example |
 |------|--------------|---------|
-| **1. Shelly fires an action** | You press/hold the input or the relay switches off. | `POST http://192.168.4.25:8000/shutdown` with body `{"token":"super-secret"}` **or**<br>`GET  http://192.168.4.25:8000/shutdown?token=super-secret` |
+| **1. Shelly fires an action** | You press/hold the input or the relay switches off. | `GET http://192.168.4.25:8000/shutdown?token=super-secret` |
 | **2. `api.py` checks the token** | Token is compared with `SHUTDOWN_TOKEN` (default `CHANGE-ME`). | — |
 | **3. Pi shuts down or reboots** | Script forks `sudo shutdown -h now` (or `reboot`). | HTTP **202 Accepted** is returned; Gunicorn exits only when the kernel halts. |
 
@@ -23,10 +23,8 @@ avoid SD-card corruption.
 
 | Purpose | Method | Full URL to paste in Shelly “Actions” |
 |---------|--------|---------------------------------------|
-| **Shut down (GET)** | **GET** | `http://<PI_IP>:8000/shutdown?token=YOUR_SECRET` |
-| **Shut down (JSON)** | **POST** | `http://<PI_IP>:8000/shutdown`<br>Body → `{"token":"YOUR_SECRET"}` |
-| **Reboot (GET)** | **GET** | `http://<PI_IP>:8000/reboot?token=YOUR_SECRET` |
-| **Reboot (JSON)** | **POST** | `http://<PI_IP>:8000/reboot`<br>Body → `{"token":"YOUR_SECRET"}` |
+| **Shut down** | **GET** | `http://<PI_IP>:8000/shutdown?token=YOUR_SECRET` |
+| **Reboot** | **GET** | `http://<PI_IP>:8000/reboot?token=YOUR_SECRET` |
 
 > **Tip:** Replace `<PI_IP>` with your Pi’s address (e.g. `192.168.4.25`) and
 > keep the secret string identical to the one in `/etc/default/pi-shutdown`.

--- a/api.py
+++ b/api.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Simple HTTP endpoint that tells a Raspberry Pi to power off
-when called with the correct token:
-    POST /shutdown {"token": "<SECRET>"}
+when called with the correct token via a GET request:
+    /shutdown?token=<SECRET>
 """
 
 import os
@@ -24,13 +24,13 @@ logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
-@app.route("/shutdown", methods=["POST"])
+@app.route("/shutdown", methods=["GET"])
 def shutdown():
     logger.info("Shutdown requested from %s", request.remote_addr)
-    data = request.get_json(silent=True)
-    if data is None:
-        abort(400, description="Missing JSON body")
-    if data.get("token") != SECRET:
+    token = request.args.get("token")
+    if token is None:
+        abort(400, description="Missing token")
+    if token != SECRET:
         abort(403, description="Bad token")
     cmd = ["sudo", *SHUTDOWN_CMD]
     logger.info("Executing command: %s", " ".join(cmd))
@@ -43,13 +43,13 @@ def shutdown():
     return "Shutting down…\n", 202
 
 
-@app.route("/reboot", methods=["POST"])
+@app.route("/reboot", methods=["GET"])
 def reboot():
     logger.info("Reboot requested from %s", request.remote_addr)
-    data = request.get_json(silent=True)
-    if data is None:
-        abort(400, description="Missing JSON body")
-    if data.get("token") != SECRET:
+    token = request.args.get("token")
+    if token is None:
+        abort(400, description="Missing token")
+    if token != SECRET:
         abort(403, description="Bad token")
     cmd = ["sudo", *REBOOT_CMD]
     logger.info("Executing command: %s", " ".join(cmd))


### PR DESCRIPTION
## Summary
- use GET parameters instead of POST JSON
- document GET-only API in the README

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e24c97cf083248be5021497be8d20