### PR TITLE
Add secret setup to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ git clone https://github.com/yourname/pi-shutdown.git
 cd pi-shutdown
 pip install -r requirements.txt        # Flask + Gunicorn
 
-# 2) (Optional) set your own secret
-echo 'SHUTDOWN_TOKEN="super-secret"' | sudo tee /etc/default/pi-shutdown
-
-# 3) Install/upgrade the systemd unit and start it
-sudo bash install.sh
+# 2) Install/upgrade the systemd unit and start it
+sudo bash install.sh        # prompts for your secret token
+```

--- a/install.sh
+++ b/install.sh
@@ -5,12 +5,23 @@ set -e
 
 DEST=/opt/pi-shutdown
 SERVICE=pi-shutdown.service
+TOKEN_FILE=/etc/default/pi-shutdown
 
 # Ensure script is running with root privileges
 if [ "$EUID" -ne 0 ]; then
     echo "This installer must be run as root (e.g. via sudo bash install.sh)" >&2
     exit 1
 fi
+
+# Prompt for shutdown token and write it to TOKEN_FILE
+DEFAULT_TOKEN=CHANGE-ME
+if [ -f "$TOKEN_FILE" ]; then
+    source "$TOKEN_FILE"
+fi
+CURRENT_TOKEN=${SHUTDOWN_TOKEN:-$DEFAULT_TOKEN}
+read -p "Enter shutdown token [${CURRENT_TOKEN}]: " TOKEN_INPUT
+TOKEN=${TOKEN_INPUT:-$CURRENT_TOKEN}
+echo "SHUTDOWN_TOKEN=\"$TOKEN\"" > "$TOKEN_FILE"
 
 # copy application files
 mkdir -p "$DEST"


### PR DESCRIPTION
## Summary
- prompt for secret in `install.sh` and save to `/etc/default/pi-shutdown`
- clarify Quick-start instructions

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2593f4948324b8e7e537dd9b9418