### PR TITLE
Make app compatible with Python 2.7 and 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,14 @@ avoid SD-card corruption.
 
 ---
 
+## Requirements
+
+The scripts are compatible with **Python 2.7.16** and **Python 3.7.3**.
+
 ## Quick-start
 
 ```bash
-# 1) Grab the code and install Python deps (as root or in a venv)
+# 1) Grab the code and install Python deps (Python 2.7 or 3.7)
 git clone https://github.com/arronlorenz/pi-shutdown-api.git
 cd pi-shutdown-api
 sudo pip install -r requirements.txt        # Flask + Gunicorn

--- a/api.py
+++ b/api.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 Simple HTTP endpoint that tells a Raspberry Pi to power off
 when called with the correct token via a GET request:
@@ -32,7 +32,7 @@ def shutdown():
         abort(400, description="Missing token")
     if token != SECRET:
         abort(403, description="Bad token")
-    cmd = ["sudo", *SHUTDOWN_CMD]
+    cmd = ["sudo"] + SHUTDOWN_CMD
     logger.info("Executing command: %s", " ".join(cmd))
     try:
         subprocess.Popen(cmd)
@@ -51,7 +51,7 @@ def reboot():
         abort(400, description="Missing token")
     if token != SECRET:
         abort(403, description="Bad token")
-    cmd = ["sudo", *REBOOT_CMD]
+    cmd = ["sudo"] + REBOOT_CMD
     logger.info("Executing command: %s", " ".join(cmd))
     try:
         subprocess.Popen(cmd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Flask>=2.3,<3
-gunicorn>=21.2,<22
+# Compatible with Python 2.7.16 and Python 3.7.3
+Flask>=1.1,<2
+gunicorn>=19,<20


### PR DESCRIPTION
## Summary
- support older Raspberry Pi OS Python versions
- relax requirements for Python 2.7/3.7 compatibility
- document supported Python versions in README

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2a195d7c8324a0cdb4988d7b34d3