### PR TITLE
Improve installer update behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ sudo pip install -r requirements.txt        # Flask + Gunicorn
 # 2) Install/upgrade the systemd unit and start it
 sudo bash install.sh        # prompts for your secret token
 ```
+
+Running `install.sh` again updates the files in place. The script stops the
+existing service, installs the new version, and then starts it back up.

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,11 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
+# Stop service before updating files so running instances don't hold old code
+if systemctl is-active --quiet "$SERVICE"; then
+    systemctl stop "$SERVICE"
+fi
+
 # Prompt for shutdown token and write it to TOKEN_FILE
 DEFAULT_TOKEN=CHANGE-ME
 if [ -f "$TOKEN_FILE" ]; then


### PR DESCRIPTION
## Summary
- add step to stop the running service before copying files
- document update flow in README

## Testing
- `python -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2b944a888324aa3d8a16ce389b00